### PR TITLE
feat(navigation): add Peramorphiq link under Research dropdown

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,5 +13,7 @@
     url: /research/gpu/
   - title: Pera Swarm
     url: https://pera-swarm.ce.pdn.ac.lk/
+  - title: Peramorphiq
+    url: https://peramorphiq.ce.pdn.ac.lk/
 - title: People
   url: /people/


### PR DESCRIPTION
Adds “Peramorphiq” to the Research dropdown via site data.